### PR TITLE
Avoid trademark issues with library name

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,10 +1,12 @@
 {
-  "name": "Arduino-AAP",
+  "name": "AAP",
   "keywords": "aap, apple, iphone, ipod, protocol",
   "description": "An Arduino library for controlling iPods (and some features for the iPod app on iPhones and iPod Touches) via the Apple Accessory Protocol (AAP)",
   "repository":
   {
     "type": "git",
     "url": "https://github.com/finsprings/arduinaap.git"
-  }
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
 }


### PR DESCRIPTION
Added frameworks and platforms fields

New location of library: http://platformio.ikravets.com/#!/lib/show/53/AAP
